### PR TITLE
feat: add versioning metadata to stream

### DIFF
--- a/src/converters/node-converters.ts
+++ b/src/converters/node-converters.ts
@@ -16,8 +16,23 @@ export function convertToStream(node: Node) {
       quad(node.metadata.stream, RDF_NAMESPACE('type'), LDES('EventStream')),
       quad(node.metadata.stream, RDF_NAMESPACE('type'), TREE('Collection')),
       quad(node.metadata.stream, TREE('view'), node.metadata.view),
-      quad(node.idNamedNode, RDF_NAMESPACE('type'), TREE('Node')),
     ]
+  );
+  if (node.metadata.timestampPath) {
+    pushToReadable(
+      quadStream,
+      quad(node.metadata.stream, LDES('timestampPath'), node.metadata.timestampPath)
+    );
+  }
+  if (node.metadata.versionOfPath) {
+    pushToReadable(
+      quadStream,
+      quad(node.metadata.stream, LDES('versionOfPath'), node.metadata.versionOfPath),
+    );
+  }
+  pushToReadable(
+    quadStream,
+    quad(node.idNamedNode, RDF_NAMESPACE('type'), TREE('Node')),
   );
 
   // Add the different relations to the store
@@ -73,11 +88,15 @@ function extractMetadata(store: Store): Metadata {
     LDES('EventStream')
   )?.subject;
   const view = getFirstMatch(store, null, TREE('view'))?.object;
+  const timestampPath = getFirstMatch(store, stream, LDES('timestampPath'), null)?.object;
+  const versionOfPath = getFirstMatch(store, stream, LDES('versionOfPath'), null)?.object;
   if (id && stream && view) {
     return {
       id: parseInt(path.parse(id.value).base),
       stream: stream as RDF.NamedNode,
       view: view as RDF.NamedNode,
+      timestampPath: timestampPath as RDF.NamedNode,
+      versionOfPath: versionOfPath as RDF.NamedNode,
     };
   } else {
     throw Error('Reference to id, stream or view not found');

--- a/src/fragmenters/time-fragmenter.ts
+++ b/src/fragmenters/time-fragmenter.ts
@@ -1,4 +1,5 @@
 import { DataFactory } from 'n3';
+import path from 'path';
 import {
   generateTreeRelation,
   generateVersion,
@@ -22,6 +23,21 @@ export default class TimeFragmenter extends Fragmenter {
     super(config, args);
     this.relationPath = namedNode(config.timeTreeRelationPath);
   }
+
+  constructNewNode(): Node {
+    const nodeId = (this.config.cache.getLastPage(this.folder) || 0) + 1;
+    this.config.cache.updateLastPage(this.folder, nodeId);
+
+    const node = new Node({
+      id: nodeId,
+      stream: this.config.streamPrefix(path.basename(this.folder)),
+      view: this.getRelationReference(nodeId, 1),
+      timestampPath: this.relationPath,
+      versionOfPath: PURL('isVersionOf'),
+    });
+    return node;
+  }
+
   constructVersionedMember(member: Member): Member {
     const versionedResourceId = generateVersion(member.id);
     const versionedMember = new Member(versionedResourceId);

--- a/src/models/node.ts
+++ b/src/models/node.ts
@@ -8,6 +8,8 @@ export type Metadata = {
   id: number;
   stream: RDF.NamedNode;
   view: RDF.NamedNode;
+  versionOfPath?: RDF.NamedNode;
+  timestampPath?: RDF.NamedNode;
 };
 
 export class Node {


### PR DESCRIPTION
The stream now contains the following triples:

```
<stream> ldes:versionOfPath dcterms:versionOf .
<stream> ldes:timestampPath $TIME_TREE_RELATION_PATH .
```

This metadata is used by certain consumers to automate the versioning of members.